### PR TITLE
統合版向けのUDPポートの開放

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - "19132:19132"
-      - "19133:19133"
+      - "19132:19132/udp"
+      - "19133:19133/udp"
       - "25565:25565"
     volumes:
       - type: bind


### PR DESCRIPTION
Java版ではTCPで、統合版ではUDPでそれぞれ通信しているようなので、ポート19132と19133をTCPポートではなくUDPポートとして開放すればよいのでは、と思いました。